### PR TITLE
Add config for designate single

### DIFF
--- a/config/charm-single/designate-trusty.yaml
+++ b/config/charm-single/designate-trusty.yaml
@@ -1,0 +1,2 @@
+designate:
+  openstack-origin: cloud:trusty-mitaka


### PR DESCRIPTION
Designate charm is for mitaka or above so add config so that charm
single sets openstack origin