### PR TITLE
Pin to websocket-client <= 0.40.0

### DIFF
--- a/tools/mojo-openstack/requirements.txt
+++ b/tools/mojo-openstack/requirements.txt
@@ -6,3 +6,4 @@ python-cinderclient>=1.0.0  # From Mojo requirements
 bzr+lp:codetree#egg=codetree
 bzr+lp:mojo#egg=mojo
 python-openstackclient
+websocket-client<=0.40.0


### PR DESCRIPTION
There are major changes to websocket-client that are not compatible
with jujuclient.
Other tools have taken this approach including bundletester.