### PR TITLE
disable ceph encrypt jobs that we know are failing

### DIFF
--- a/config/jjb-templates/project-mojo-matrix.yaml
+++ b/config/jjb-templates/project-mojo-matrix.yaml
@@ -1010,12 +1010,12 @@
           - "trusty-icehouse"
           # - "trusty-kilo"    # Same ceph version as Liberty UCA
           - "trusty-liberty"
-          - "trusty-mitaka"
-          - "xenial-mitaka"
+          # - "trusty-mitaka" # Pending https://bugs.launchpad.net/charm-ceph-osd/+bug/1604501
+          # - "xenial-mitaka" # Pending https://bugs.launchpad.net/charm-ceph-osd/+bug/1604501
           # - "xenial-newton"  # Same ceph version as Mitaka UCA
           # - "xenial-ocata"   # Same ceph version as Mitaka UCA
-          - "xenial-pike"
-          - "zesty-ocata"
+          # - "xenial-pike" # Pending https://bugs.launchpad.net/charm-ceph-osd/+bug/1604501
+          # - "zesty-ocata" # Pending https://bugs.launchpad.net/charm-ceph-osd/+bug/1604501
           # - "artful-pike"    # Pending https://bugs.launchpad.net/juju/+bug/1714305
     builders:
       - trigger-builds:


### PR DESCRIPTION
These jobs are failing with due to an existing, long standing
bug, filed against both the charms and upstream.

Related-Bug: #1604501