### PR TITLE
attempt to use ci config

### DIFF
--- a/config/jjb-templates/jjb-ci.conf
+++ b/config/jjb-templates/jjb-ci.conf
@@ -1,0 +1,10 @@
+# Need to populate with creds and url, save as jjb-run.conf.
+[job_builder]
+ignore_cache=True
+allow_duplicates=False
+
+[jenkins]
+user=CHANGEME1234
+password=CHANGEME1234
+url=http://127.0.0.1:8080/
+

--- a/tox.ini
+++ b/tox.ini
@@ -17,4 +17,4 @@ commands = bash -ex tests/validate_yaml_load.sh
 
 [testenv:jjb_test]
 deps = -r{toxinidir}/config/jjb-templates/jjb-requirements.txt
-commands = jenkins-jobs --ignore-cache test config/jjb-templates
+commands = jenkins-jobs --conf config/jjb-templates/jjb-ci.conf --ignore-cache test config/jjb-templates


### PR DESCRIPTION
If we use an IP instead of a [default] hostname, it does not throw an exception