### PR TITLE
Revert "remove scheduling during release testing (#53)"

### DIFF
--- a/config/jjb-templates/project-mojo-matrix.yaml
+++ b/config/jjb-templates/project-mojo-matrix.yaml
@@ -8,7 +8,7 @@
       sequential: false
     node: task
     triggers:
-        - timed: "0 0 1 2 *"  # Once daily
+        - timed: "H H(17-23) * * *"  # Once daily
     axes:
       - axis:
          type: user-defined
@@ -43,7 +43,7 @@
       sequential: false
     node: task
     triggers:
-        - timed: "0 0 1 2 *"  # Once weekly on Friday Evening / Saturday Morning
+        - timed: "H H(04-08) * * 6"  # Once weekly on Friday Evening / Saturday Morning
     axes:
       - axis:
          type: user-defined
@@ -85,7 +85,7 @@
       sequential: true
     node: task
     triggers:
-        - timed: "0 0 1 2 *"  # Twice monthly
+        - timed: "0 H(0-8) */15 * *"  # Twice monthly
     axes:
       - axis:
          type: user-defined
@@ -124,7 +124,7 @@
       sequential: false
     node: task
     triggers:
-        - timed: "0 0 1 2 *"  # Once weekly on Thursday evening
+        - timed: "H H(19-23) * * 4"  # Once weekly on Thursday evening
     axes:
       - axis:
          type: user-defined
@@ -167,7 +167,7 @@
       sequential: true
     node: task
     triggers:
-        - timed: "0 0 1 2 *"  # Twice monthly
+        - timed: "0 H(0-8) */15 * *"  # Twice monthly
     axes:
       - axis:
          type: user-defined
@@ -206,7 +206,7 @@
       sequential: false
     node: task
     triggers:
-        - timed: "0 0 1 2 *"  # Once weekly on Monday Evening / Tuesday Morning
+        - timed: "H H(00-04) * * 2"  # Once weekly on Monday Evening / Tuesday Morning
     axes:
       - axis:
          type: user-defined
@@ -248,7 +248,7 @@
       sequential: true
     node: task
     triggers:
-        - timed: "0 0 1 2 *"  # Twice monthly
+        - timed: "0 H(0-8) */15 * *"  # Twice monthly
     axes:
       - axis:
          type: user-defined
@@ -287,7 +287,7 @@
       sequential: false
     node: task
     triggers:
-        - timed: "0 0 1 2 *"  # Once weekly on Wednesday Evening / Thursday Morning
+        - timed: "H H(00-04) * * 4"  # Once weekly on Wednesday Evening / Thursday Morning
     axes:
       - axis:
          type: user-defined
@@ -329,7 +329,7 @@
       sequential: true
     node: task
     triggers:
-        - timed: "0 0 1 2 *"  # Twice monthly
+        - timed: "0 H(0-8) */15 * *"  # Twice monthly
     axes:
       - axis:
          type: user-defined
@@ -368,7 +368,7 @@
       sequential: false
     node: task
     triggers:
-        - timed: "0 0 1 2 *"  # Once weekly on Saturday Evening / Sunday Morning
+        - timed: "H H(00-04) * * 7"  # Once weekly on Saturday Evening / Sunday Morning
     axes:
       - axis:
          type: user-defined
@@ -408,7 +408,7 @@
       sequential: true
     node: task
     triggers:
-        - timed: "0 0 1 2 *"  # Twice monthly
+        - timed: "0 H(0-8) */15 * *"  # Twice monthly
     axes:
       - axis:
          type: user-defined
@@ -447,7 +447,7 @@
       sequential: false
     node: task
     triggers:
-        - timed: "0 0 1 2 *"  # Twice monthly
+        - timed: "0 H(0-8) */15 * *"  # Twice monthly
     axes:
       - axis:
          type: user-defined
@@ -486,7 +486,7 @@
       sequential: false
     node: task
     triggers:
-        - timed: "0 0 1 2 *"  # Once weekly on Saturday Morning
+        - timed: "H H(06-10) * * 6"  # Once weekly on Saturday Morning
     axes:
       - axis:
          type: user-defined
@@ -525,7 +525,7 @@
       sequential: false
     node: task
     triggers:
-        - timed: "0 0 1 2 *"  # Once weekly on Friday nights
+        - timed: "H H(17-23) * * 5"  # Once weekly on Friday nights
     axes:
       - axis:
          type: user-defined
@@ -567,7 +567,7 @@
       sequential: true
     node: task
     triggers:
-        - timed: "0 0 1 2 *"  # Once weekly on Sunday Afternoon
+        - timed: "H H(12-16) * * 7"  # Once weekly on Sunday Afternoon
     axes:
       - axis:
          type: user-defined
@@ -609,7 +609,7 @@
       sequential: false
     node: task
     triggers:
-        - timed: "0 0 1 2 *"  # Once weekly on Friday nights
+        - timed: "H H(00-04) * * 1"  # Once weekly on Friday nights
     axes:
       - axis:
          type: user-defined
@@ -651,7 +651,7 @@
       sequential: true
     node: task
     triggers:
-        - timed: "0 0 1 2 *"  # Twice monthly
+        - timed: "0 H(0-8) */15 * *"  # Twice monthly
     axes:
       - axis:
          type: user-defined
@@ -750,7 +750,7 @@
       sequential: false
     node: task
     triggers:
-        - timed: "0 0 1 2 *"  # Once weekly on Saturday mornings
+        - timed: "H H(04-06) * * 6"  # Once weekly on Saturday mornings
     axes:
       - axis:
          type: user-defined
@@ -792,7 +792,7 @@
       sequential: false
     node: task
     triggers:
-        - timed: "0 0 1 2 *"  # Once weekly on Wednesday nights
+        - timed: "H H(22-0) * * 3"  # Once weekly on Wednesday nights
     axes:
       - axis:
          type: user-defined
@@ -834,7 +834,7 @@
       sequential: false
     node: task
     triggers:
-        - timed: "0 0 1 2 *"  # Once weekly on Saturday mornings
+        - timed: "H H(03-05) * * 6"  # Once weekly on Saturday mornings
     axes:
       - axis:
          type: user-defined
@@ -876,7 +876,7 @@
       sequential: false
     node: task
     triggers:
-        - timed: "0 0 1 2 *"  # Once weekly on Tuesday nights
+        - timed: "H H(21-23) * * 2"  # Once weekly on Tuesday nights
     axes:
       - axis:
          type: user-defined
@@ -918,7 +918,7 @@
       sequential: false
     node: task
     triggers:
-        - timed: "0 0 1 2 *"  # Once weekly on Friday nights
+        - timed: "H H(21-23) * * 5"  # Once weekly on Friday nights
     axes:
       - axis:
          type: user-defined
@@ -960,7 +960,7 @@
       sequential: false
     node: task
     triggers:
-        - timed: "0 0 1 2 *"  # Once weekly on Saturday Morningns
+        - timed: "H H(00-04) * * 6"  # Once weekly on Saturday Morningns
     axes:
       - axis:
          type: user-defined
@@ -1000,7 +1000,7 @@
       sequential: false
     node: task
     triggers:
-        - timed: "0 0 1 2 *"  # Once weekly on Saturday Morningns
+        - timed: "H H(01-05) * * 6"  # Once weekly on Saturday Morningns
     axes:
       - axis:
          type: user-defined
@@ -1042,7 +1042,7 @@
       sequential: false
     node: task
     triggers:
-        - timed: "0 0 1 2 *"  # Once weekly on Saturday Morningns
+        - timed: "H H(02-06) * * 6"  # Once weekly on Saturday Morningns
     axes:
       - axis:
          type: user-defined
@@ -1084,7 +1084,7 @@
       sequential: false
     node: task
     triggers:
-        - timed: "0 0 1 2 *"  # Once weekly on Monday Evening / Tuesday Morning
+        - timed: "H H(00-04) * * 2"  # Once weekly on Monday Evening / Tuesday Morning
     axes:
       - axis:
          type: user-defined


### PR DESCRIPTION
This reverts commit 66a03179dbf856c42b980453b308c22620c11775 and shouldn't be merged until we're ready to re-enable scheduled testing