### PR TITLE
Update tox.ini to stop using unverified package

### DIFF
--- a/config/jjb-templates/tox.ini
+++ b/config/jjb-templates/tox.ini
@@ -7,7 +7,7 @@ setenv = VIRTUAL_ENV={envdir}
          PYTHONHASHSEED=0
 passenv = HOME TERM
 install_command =
-  pip install --allow-unverified python-apt {opts} {packages}
+  pip install {opts} {packages}
 
 [testenv:jjb]
 basepython = python3

--- a/tools/openstack-client-venv/tox.ini
+++ b/tools/openstack-client-venv/tox.ini
@@ -7,7 +7,7 @@ setenv = VIRTUAL_ENV={envdir}
          PYTHONHASHSEED=0
 passenv = HOME TERM
 install_command =
-  pip install --allow-unverified python-apt {opts} {packages}
+  pip install {opts} {packages}
 
 [testenv:openstack-client]
 basepython = python2.7

--- a/tools/tox.ini
+++ b/tools/tox.ini
@@ -6,7 +6,7 @@ skipsdist = True
 setenv = VIRTUAL_ENV={envdir}
          PYTHONHASHSEED=0
 install_command =
-  pip install --allow-unverified python-apt {opts} {packages}
+  pip install {opts} {packages}
 commands = ostestr {posargs}
 
 [testenv:py35]


### PR DESCRIPTION
As of pip 10.0, --allow-unverified is not permitted.  The usage of that in this repo was accidental and not actually required.