### PR TITLE
Add neutron-dynamic-routing charm-single config for xenial

### DIFF
--- a/config/charm-single/neutron-dynamic-routing-xenial.yaml
+++ b/config/charm-single/neutron-dynamic-routing-xenial.yaml
@@ -1,0 +1,2 @@
+neutron-dynamic-routing:
+  openstack-origin: cloud:xenial-pike


### PR DESCRIPTION
Minimal supported OpenStack release is Pike

Reference: https://openstack-ci-reports.ubuntu.com/artifacts/test_charm_pipeline/openstack/charm-neutron-dynamic-routing/568260/6/4517/test_charm_single_27341/logs/neutron-dynamic-routing-x-0-var-log.tar.bz2