### PR TITLE
Switch the default mojo branch to the 1805 one

### DIFF
--- a/config/jjb-templates/project-mojo-matrix.yaml
+++ b/config/jjb-templates/project-mojo-matrix.yaml
@@ -753,7 +753,7 @@
           description: Git repo for Mojo OpenStack Specs
       - string:
           name: MOJO_OPENSTACK_SPECS_BRANCH
-          default: "master"
+          default: "openstack-mojo-specs-1805"
           description: Git branch for Mojo OpenStack Specs repo
       - NO_POST_DESTROY
       - DISPLAY_NAME


### PR DESCRIPTION
Use the 1805 branch for mojo testing during the release test period.
Looking at commit c074fa51 this seems to be how it was done for 1802