### PR TITLE
Change back to the master branch of openstack-mojo-specs

### DIFF
--- a/config/jjb-templates/project-mojo-matrix.yaml
+++ b/config/jjb-templates/project-mojo-matrix.yaml
@@ -753,7 +753,7 @@
           description: Git repo for Mojo OpenStack Specs
       - string:
           name: MOJO_OPENSTACK_SPECS_BRANCH
-          default: "openstack-mojo-specs-1805"
+          default: "master"
           description: Git branch for Mojo OpenStack Specs repo
       - NO_POST_DESTROY
       - DISPLAY_NAME


### PR DESCRIPTION
Switch us back to master after https://github.com/openstack-charmers/openstack-mojo-specs/pull/33 is merged.