### PR TITLE
Switch the default mojo specs branch to 1808

### DIFF
--- a/config/jjb-templates/project-mojo-matrix.yaml
+++ b/config/jjb-templates/project-mojo-matrix.yaml
@@ -759,7 +759,7 @@
           description: Git repo for Mojo OpenStack Specs
       - string:
           name: MOJO_OPENSTACK_SPECS_BRANCH
-          default: "master"
+          default: "openstack-mojo-specs-1808"
           description: Git branch for Mojo OpenStack Specs repo
       - NO_POST_DESTROY
       - DISPLAY_NAME


### PR DESCRIPTION
Use the 1808 branch for mojo testing during the release test period.