### PR TITLE
Skip `charm-single` job for `Octavia` charm

### DIFF
--- a/config/charm-single/octavia.skip
+++ b/config/charm-single/octavia.skip
@@ -1,0 +1,4 @@
+# The octavia charm does not have `xenial` series support and the
+# `charm-single` job assumes every charm does.
+#
+# https://bugs.launchpad.net/ubuntu-openstack-ci/+bug/1799376


### PR DESCRIPTION
The octavia charm does not have `xenial` series support and the `charm-single` job assumes every charm does.

https://bugs.launchpad.net/ubuntu-openstack-ci/+bug/1799376