### PR TITLE
update spec branch to 1811

### DIFF
--- a/config/jjb-templates/project-mojo-matrix.yaml
+++ b/config/jjb-templates/project-mojo-matrix.yaml
@@ -759,7 +759,7 @@
           description: Git repo for Mojo OpenStack Specs
       - string:
           name: MOJO_OPENSTACK_SPECS_BRANCH
-          default: "openstack-mojo-specs-1808"
+          default: "openstack-mojo-specs-1811"
           description: Git branch for Mojo OpenStack Specs repo
       - NO_POST_DESTROY
       - DISPLAY_NAME


### PR DESCRIPTION
Switch OSCI to the release branch for 1811 - https://github.com/openstack-charmers/openstack-mojo-specs/compare/master...openstack-mojo-specs-1811