### PR TITLE
Remove old trustys

### DIFF
--- a/config/jjb-templates/project-mojo-matrix.yaml
+++ b/config/jjb-templates/project-mojo-matrix.yaml
@@ -54,7 +54,6 @@
          type: user-defined
          name: U_OS
          values:
-          - "trusty-kilo"
           - "trusty-liberty"
           - "trusty-mitaka"
           - "xenial-mitaka"
@@ -97,7 +96,6 @@
          type: user-defined
          name: U_OS
          values:
-          - "trusty-kilo"
           - "trusty-liberty"
           - "trusty-mitaka"
           - "xenial-mitaka"
@@ -135,7 +133,6 @@
          type: user-defined
          name: U_OS
          values:
-          - "trusty-kilo"
           - "trusty-liberty"
           - "trusty-mitaka"
           - "xenial-mitaka"
@@ -178,7 +175,6 @@
          type: user-defined
          name: U_OS
          values:
-          - "trusty-kilo"
           - "trusty-liberty"
           - "trusty-mitaka"
           - "xenial-mitaka"
@@ -216,7 +212,6 @@
          type: user-defined
          name: U_OS
          values:
-          - "trusty-kilo"
           - "trusty-liberty"
           - "trusty-mitaka"
           - "xenial-mitaka"
@@ -259,7 +254,6 @@
          type: user-defined
          name: U_OS
          values:
-          - "trusty-kilo"
           - "trusty-liberty"
           - "trusty-mitaka"
           - "xenial-mitaka"
@@ -380,7 +374,6 @@
          type: user-defined
          name: U_OS
          values:
-          - "trusty-kilo"
           - "trusty-liberty"
           # - "trusty-mitaka"        # Nothing to upgrade to.
           - "xenial-mitaka"
@@ -421,7 +414,6 @@
          type: user-defined
          name: U_OS
          values:
-          - "trusty-kilo"
           - "trusty-liberty"
           # - "trusty-mitaka"         # Nothing to upgrade to.
           - "xenial-mitaka"
@@ -459,7 +451,6 @@
          type: user-defined
          name: U_OS
          values:
-          - "trusty-kilo"
           - "trusty-liberty"
           - "trusty-mitaka"
           - "xenial-mitaka"
@@ -501,7 +492,6 @@
          type: user-defined
          name: U_OS
          values:
-          - "trusty-kilo"
           - "trusty-liberty"
           - "trusty-mitaka"
           - "xenial-mitaka"
@@ -542,7 +532,6 @@
          type: user-defined
          name: U_OS
          values:
-          - "trusty-kilo"
           - "trusty-liberty"
           - "trusty-mitaka"
           - "xenial-mitaka"
@@ -584,7 +573,6 @@
          type: user-defined
          name: U_OS
          values:
-          - "trusty-kilo"
           - "trusty-liberty"
           - "trusty-mitaka"
           - "xenial-mitaka"
@@ -627,7 +615,6 @@
          name: U_OS
          values:
           # - "trusty-icehouse"   # No spec defined, unsupported combo.
-          - "trusty-kilo"
           - "trusty-liberty"
           - "trusty-mitaka"
           - "xenial-mitaka"
@@ -670,7 +657,6 @@
          type: user-defined
          name: U_OS
          values:
-          - "trusty-kilo"
           - "trusty-liberty"
           - "trusty-mitaka"
           - "xenial-mitaka"
@@ -770,7 +756,6 @@
          type: user-defined
          name: U_OS
          values:
-          - "trusty-kilo"
           - "trusty-liberty"
           - "trusty-mitaka"
           - "xenial-mitaka"
@@ -812,7 +797,6 @@
          type: user-defined
          name: U_OS
          values:
-          - "trusty-kilo"
           - "trusty-liberty"
           - "trusty-mitaka"
           - "xenial-mitaka"
@@ -1145,7 +1129,6 @@
          type: user-defined
          name: U_OS
          values:
-          - "trusty-kilo"
           - "trusty-liberty"
           - "trusty-mitaka"
           - "xenial-mitaka"

--- a/config/jjb-templates/project-mojo-matrix.yaml
+++ b/config/jjb-templates/project-mojo-matrix.yaml
@@ -285,8 +285,6 @@
          type: user-defined
          name: U_OS
          values:
-          # - "trusty-icehouse"  # No KSV3 support in Icehouse
-          # - "trusty-kilo"      # No KSV3 support in Kilo     # Early KSV3 support
           - "trusty-mitaka"
           - "xenial-mitaka"
           - "xenial-newton"
@@ -328,8 +326,6 @@
          type: user-defined
          name: U_OS
          values:
-          # - "trusty-icehouse"  # No KSV3 support in Icehouse
-          # - "trusty-kilo"      # No KSV3 support in Kilo     # Early KSV3 support
           - "trusty-mitaka"
           - "xenial-mitaka"
           - "xenial-newton"
@@ -600,7 +596,6 @@
          type: user-defined
          name: U_OS
          values:
-          # - "trusty-icehouse"   # No spec defined, unsupported combo.
           - "trusty-mitaka"
           - "xenial-mitaka"
           - "xenial-newton"
@@ -820,7 +815,6 @@
          type: user-defined
          name: U_OS
          values:
-          # - "trusty-kilo"    # Same ceph version as Liberty UCA
           - "trusty-mitaka"
           - "xenial-mitaka"
           # - "xenial-newton"  # Same ceph version as Mitaka UCA
@@ -861,7 +855,6 @@
          type: user-defined
          name: U_OS
          values:
-          # - "trusty-kilo"    # Same ceph version as Liberty UCA
           - "trusty-mitaka"
           - "xenial-mitaka"
           # - "xenial-newton"  # Same ceph version as Mitaka UCA
@@ -902,7 +895,6 @@
          type: user-defined
          name: U_OS
          values:
-          # - "trusty-kilo"    # Same ceph version as Liberty UCA
           - "trusty-mitaka"
           - "xenial-mitaka"
           # - "xenial-newton"  # Same ceph version as Mitaka UCA
@@ -943,7 +935,6 @@
          type: user-defined
          name: U_OS
          values:
-          # - "trusty-kilo"    # Same ceph version as Liberty UCA
           - "trusty-mitaka"
           - "xenial-mitaka"
           # - "xenial-newton"  # Same ceph version as Mitaka UCA
@@ -981,7 +972,6 @@
          type: user-defined
          name: U_OS
          values:
-          # - "trusty-kilo"    # Same ceph version as Liberty UCA
           # - "trusty-mitaka" # Pending https://bugs.launchpad.net/charm-ceph-osd/+bug/1604501
           # - "xenial-mitaka" # Pending https://bugs.launchpad.net/charm-ceph-osd/+bug/1604501
           # - "xenial-newton"  # Same ceph version as Mitaka UCA
@@ -1022,7 +1012,6 @@
          type: user-defined
          name: U_OS
          values:
-          # - "trusty-kilo"    # Same ceph version as Liberty UCA
           - "trusty-mitaka"
           - "xenial-mitaka"
           # - "xenial-newton"  # Same ceph version as Mitaka UCA
@@ -1063,9 +1052,6 @@
          type: user-defined
          name: U_OS
          values:
-          # - "trusty-icehouse"   # Unsupported combo for these features.
-          # - "trusty-kilo"       # Unsupported combo for these features.
-          # - "trusty-liberty"    # Unsupported combo for these features.
           - "trusty-mitaka"
           - "xenial-mitaka"
           - "xenial-newton"

--- a/config/jjb-templates/project-mojo-matrix.yaml
+++ b/config/jjb-templates/project-mojo-matrix.yaml
@@ -54,7 +54,6 @@
          type: user-defined
          name: U_OS
          values:
-          - "trusty-liberty"
           - "trusty-mitaka"
           - "xenial-mitaka"
           - "xenial-newton"
@@ -96,7 +95,6 @@
          type: user-defined
          name: U_OS
          values:
-          - "trusty-liberty"
           - "trusty-mitaka"
           - "xenial-mitaka"
           - "xenial-newton"
@@ -133,7 +131,6 @@
          type: user-defined
          name: U_OS
          values:
-          - "trusty-liberty"
           - "trusty-mitaka"
           - "xenial-mitaka"
           - "xenial-newton"
@@ -175,7 +172,6 @@
          type: user-defined
          name: U_OS
          values:
-          - "trusty-liberty"
           - "trusty-mitaka"
           - "xenial-mitaka"
           - "xenial-newton"
@@ -212,7 +208,6 @@
          type: user-defined
          name: U_OS
          values:
-          - "trusty-liberty"
           - "trusty-mitaka"
           - "xenial-mitaka"
           - "xenial-newton"
@@ -254,7 +249,6 @@
          type: user-defined
          name: U_OS
          values:
-          - "trusty-liberty"
           - "trusty-mitaka"
           - "xenial-mitaka"
           - "xenial-newton"
@@ -292,8 +286,7 @@
          name: U_OS
          values:
           # - "trusty-icehouse"  # No KSV3 support in Icehouse
-          # - "trusty-kilo"      # No KSV3 support in Kilo
-          - "trusty-liberty"     # Early KSV3 support
+          # - "trusty-kilo"      # No KSV3 support in Kilo     # Early KSV3 support
           - "trusty-mitaka"
           - "xenial-mitaka"
           - "xenial-newton"
@@ -336,8 +329,7 @@
          name: U_OS
          values:
           # - "trusty-icehouse"  # No KSV3 support in Icehouse
-          # - "trusty-kilo"      # No KSV3 support in Kilo
-          - "trusty-liberty"     # Early KSV3 support
+          # - "trusty-kilo"      # No KSV3 support in Kilo     # Early KSV3 support
           - "trusty-mitaka"
           - "xenial-mitaka"
           - "xenial-newton"
@@ -374,7 +366,6 @@
          type: user-defined
          name: U_OS
          values:
-          - "trusty-liberty"
           # - "trusty-mitaka"        # Nothing to upgrade to.
           - "xenial-mitaka"
           - "xenial-newton"
@@ -414,7 +405,6 @@
          type: user-defined
          name: U_OS
          values:
-          - "trusty-liberty"
           # - "trusty-mitaka"         # Nothing to upgrade to.
           - "xenial-mitaka"
           - "xenial-newton"
@@ -451,7 +441,6 @@
          type: user-defined
          name: U_OS
          values:
-          - "trusty-liberty"
           - "trusty-mitaka"
           - "xenial-mitaka"
           - "xenial-newton"
@@ -492,7 +481,6 @@
          type: user-defined
          name: U_OS
          values:
-          - "trusty-liberty"
           - "trusty-mitaka"
           - "xenial-mitaka"
           - "xenial-newton"
@@ -532,7 +520,6 @@
          type: user-defined
          name: U_OS
          values:
-          - "trusty-liberty"
           - "trusty-mitaka"
           - "xenial-mitaka"
           - "xenial-newton"
@@ -573,7 +560,6 @@
          type: user-defined
          name: U_OS
          values:
-          - "trusty-liberty"
           - "trusty-mitaka"
           - "xenial-mitaka"
           - "xenial-newton"
@@ -615,7 +601,6 @@
          name: U_OS
          values:
           # - "trusty-icehouse"   # No spec defined, unsupported combo.
-          - "trusty-liberty"
           - "trusty-mitaka"
           - "xenial-mitaka"
           - "xenial-newton"
@@ -657,7 +642,6 @@
          type: user-defined
          name: U_OS
          values:
-          - "trusty-liberty"
           - "trusty-mitaka"
           - "xenial-mitaka"
           - "xenial-newton"
@@ -756,7 +740,6 @@
          type: user-defined
          name: U_OS
          values:
-          - "trusty-liberty"
           - "trusty-mitaka"
           - "xenial-mitaka"
           - "xenial-newton"
@@ -797,7 +780,6 @@
          type: user-defined
          name: U_OS
          values:
-          - "trusty-liberty"
           - "trusty-mitaka"
           - "xenial-mitaka"
           - "xenial-newton"
@@ -839,7 +821,6 @@
          name: U_OS
          values:
           # - "trusty-kilo"    # Same ceph version as Liberty UCA
-          - "trusty-liberty"
           - "trusty-mitaka"
           - "xenial-mitaka"
           # - "xenial-newton"  # Same ceph version as Mitaka UCA
@@ -881,7 +862,6 @@
          name: U_OS
          values:
           # - "trusty-kilo"    # Same ceph version as Liberty UCA
-          - "trusty-liberty"
           - "trusty-mitaka"
           - "xenial-mitaka"
           # - "xenial-newton"  # Same ceph version as Mitaka UCA
@@ -923,7 +903,6 @@
          name: U_OS
          values:
           # - "trusty-kilo"    # Same ceph version as Liberty UCA
-          - "trusty-liberty"
           - "trusty-mitaka"
           - "xenial-mitaka"
           # - "xenial-newton"  # Same ceph version as Mitaka UCA
@@ -965,7 +944,6 @@
          name: U_OS
          values:
           # - "trusty-kilo"    # Same ceph version as Liberty UCA
-          - "trusty-liberty"
           - "trusty-mitaka"
           - "xenial-mitaka"
           # - "xenial-newton"  # Same ceph version as Mitaka UCA
@@ -1004,7 +982,6 @@
          name: U_OS
          values:
           # - "trusty-kilo"    # Same ceph version as Liberty UCA
-          - "trusty-liberty"
           # - "trusty-mitaka" # Pending https://bugs.launchpad.net/charm-ceph-osd/+bug/1604501
           # - "xenial-mitaka" # Pending https://bugs.launchpad.net/charm-ceph-osd/+bug/1604501
           # - "xenial-newton"  # Same ceph version as Mitaka UCA
@@ -1046,7 +1023,6 @@
          name: U_OS
          values:
           # - "trusty-kilo"    # Same ceph version as Liberty UCA
-          - "trusty-liberty"
           - "trusty-mitaka"
           - "xenial-mitaka"
           # - "xenial-newton"  # Same ceph version as Mitaka UCA
@@ -1129,7 +1105,6 @@
          type: user-defined
          name: U_OS
          values:
-          - "trusty-liberty"
           - "trusty-mitaka"
           - "xenial-mitaka"
           - "xenial-newton"

--- a/config/jjb-templates/project-mojo-matrix.yaml
+++ b/config/jjb-templates/project-mojo-matrix.yaml
@@ -54,7 +54,6 @@
          type: user-defined
          name: U_OS
          values:
-          - "trusty-icehouse"
           - "trusty-kilo"
           - "trusty-liberty"
           - "trusty-mitaka"
@@ -98,7 +97,6 @@
          type: user-defined
          name: U_OS
          values:
-          - "trusty-icehouse"
           - "trusty-kilo"
           - "trusty-liberty"
           - "trusty-mitaka"
@@ -137,7 +135,6 @@
          type: user-defined
          name: U_OS
          values:
-          - "trusty-icehouse"
           - "trusty-kilo"
           - "trusty-liberty"
           - "trusty-mitaka"
@@ -181,7 +178,6 @@
          type: user-defined
          name: U_OS
          values:
-          - "trusty-icehouse"
           - "trusty-kilo"
           - "trusty-liberty"
           - "trusty-mitaka"
@@ -220,7 +216,6 @@
          type: user-defined
          name: U_OS
          values:
-          - "trusty-icehouse"
           - "trusty-kilo"
           - "trusty-liberty"
           - "trusty-mitaka"
@@ -264,7 +259,6 @@
          type: user-defined
          name: U_OS
          values:
-          - "trusty-icehouse"
           - "trusty-kilo"
           - "trusty-liberty"
           - "trusty-mitaka"
@@ -386,7 +380,6 @@
          type: user-defined
          name: U_OS
          values:
-          - "trusty-icehouse"
           - "trusty-kilo"
           - "trusty-liberty"
           # - "trusty-mitaka"        # Nothing to upgrade to.
@@ -428,7 +421,6 @@
          type: user-defined
          name: U_OS
          values:
-          - "trusty-icehouse"
           - "trusty-kilo"
           - "trusty-liberty"
           # - "trusty-mitaka"         # Nothing to upgrade to.
@@ -467,7 +459,6 @@
          type: user-defined
          name: U_OS
          values:
-          - "trusty-icehouse"
           - "trusty-kilo"
           - "trusty-liberty"
           - "trusty-mitaka"
@@ -510,7 +501,6 @@
          type: user-defined
          name: U_OS
          values:
-          - "trusty-icehouse"
           - "trusty-kilo"
           - "trusty-liberty"
           - "trusty-mitaka"
@@ -552,7 +542,6 @@
          type: user-defined
          name: U_OS
          values:
-          - "trusty-icehouse"
           - "trusty-kilo"
           - "trusty-liberty"
           - "trusty-mitaka"
@@ -595,7 +584,6 @@
          type: user-defined
          name: U_OS
          values:
-          - "trusty-icehouse"
           - "trusty-kilo"
           - "trusty-liberty"
           - "trusty-mitaka"
@@ -682,7 +670,6 @@
          type: user-defined
          name: U_OS
          values:
-          - "trusty-icehouse"
           - "trusty-kilo"
           - "trusty-liberty"
           - "trusty-mitaka"
@@ -783,7 +770,6 @@
          type: user-defined
          name: U_OS
          values:
-          - "trusty-icehouse"
           - "trusty-kilo"
           - "trusty-liberty"
           - "trusty-mitaka"
@@ -826,7 +812,6 @@
          type: user-defined
          name: U_OS
          values:
-          - "trusty-icehouse"
           - "trusty-kilo"
           - "trusty-liberty"
           - "trusty-mitaka"
@@ -869,7 +854,6 @@
          type: user-defined
          name: U_OS
          values:
-          - "trusty-icehouse"
           # - "trusty-kilo"    # Same ceph version as Liberty UCA
           - "trusty-liberty"
           - "trusty-mitaka"
@@ -912,7 +896,6 @@
          type: user-defined
          name: U_OS
          values:
-          - "trusty-icehouse"
           # - "trusty-kilo"    # Same ceph version as Liberty UCA
           - "trusty-liberty"
           - "trusty-mitaka"
@@ -955,7 +938,6 @@
          type: user-defined
          name: U_OS
          values:
-          - "trusty-icehouse"
           # - "trusty-kilo"    # Same ceph version as Liberty UCA
           - "trusty-liberty"
           - "trusty-mitaka"
@@ -998,7 +980,6 @@
          type: user-defined
          name: U_OS
          values:
-          - "trusty-icehouse"
           # - "trusty-kilo"    # Same ceph version as Liberty UCA
           - "trusty-liberty"
           - "trusty-mitaka"
@@ -1038,7 +1019,6 @@
          type: user-defined
          name: U_OS
          values:
-          - "trusty-icehouse"
           # - "trusty-kilo"    # Same ceph version as Liberty UCA
           - "trusty-liberty"
           # - "trusty-mitaka" # Pending https://bugs.launchpad.net/charm-ceph-osd/+bug/1604501
@@ -1081,7 +1061,6 @@
          type: user-defined
          name: U_OS
          values:
-          - "trusty-icehouse"
           # - "trusty-kilo"    # Same ceph version as Liberty UCA
           - "trusty-liberty"
           - "trusty-mitaka"


### PR DESCRIPTION
Per guidance from @ryan-beisner, we are removing most of the trusty combinations from the mojo matrix for the 19.04 release, but maintaining the testing for trusty-mitaka as a transition point to xenial