### PR TITLE
Skip charm-single for pacemaker remote

### DIFF
--- a/config/charm-single/pacemaker-remote.skip
+++ b/config/charm-single/pacemaker-remote.skip
@@ -1,0 +1,4 @@
+# The pacemaker-remote charm does not have `xenial` series support and the
+# `charm-single` job assumes every charm does.
+#
+# https://bugs.launchpad.net/ubuntu-openstack-ci/+bug/1799376


### PR DESCRIPTION
As beisner notes here https://review.openstack.org/#/c/652038/
we need to skip running charm-single for pacemaker-remote charm as
it does not support xeenial and charm,-single assumes all charms do.