### PR TITLE
Skip charm-single for masakari charms

### DIFF
--- a/config/charm-single/masakari-monitors.skip
+++ b/config/charm-single/masakari-monitors.skip
@@ -1,0 +1,4 @@
+# The octavia charm does not have `xenial` series support and the
+# `charm-single` job assumes every charm does.
+#
+# https://bugs.launchpad.net/ubuntu-openstack-ci/+bug/1799376

--- a/config/charm-single/masakari-monitors.skip
+++ b/config/charm-single/masakari-monitors.skip
@@ -1,4 +1,4 @@
-# The octavia charm does not have `xenial` series support and the
+# The masakari-monitors charm does not have `xenial` series support and the
 # `charm-single` job assumes every charm does.
 #
 # https://bugs.launchpad.net/ubuntu-openstack-ci/+bug/1799376

--- a/config/charm-single/masakari.skip
+++ b/config/charm-single/masakari.skip
@@ -1,0 +1,4 @@
+# The octavia charm does not have `xenial` series support and the
+# `charm-single` job assumes every charm does.
+#
+# https://bugs.launchpad.net/ubuntu-openstack-ci/+bug/1799376

--- a/config/charm-single/masakari.skip
+++ b/config/charm-single/masakari.skip
@@ -1,4 +1,4 @@
-# The octavia charm does not have `xenial` series support and the
+# The masakari charm does not have `xenial` series support and the
 # `charm-single` job assumes every charm does.
 #
 # https://bugs.launchpad.net/ubuntu-openstack-ci/+bug/1799376


### PR DESCRIPTION
The masakari charms do not support deployment on xenial.