### PR TITLE
Disable stable_to_next charm upgrade spec

### DIFF
--- a/config/jjb-templates/project-mojo-matrix.yaml
+++ b/config/jjb-templates/project-mojo-matrix.yaml
@@ -428,6 +428,7 @@
 
 - job:
     name: test_mojo_charm_upgrade_ha_matrix
+    disabled: true  # Missing memcached relation https://bugs.launchpad.net/openstack-mojo-specs/+bug/1836796
     project-type: matrix
     description: |
         <p><i>Dynamically Generated Job - Do not edit through the Jenkins Web UI.  You will lose your changes.</i></p>


### PR DESCRIPTION
When the spec/bundle issue is resolved, this can be re-enabled.

https://bugs.launchpad.net/openstack-mojo-specs/+bug/1836796