### PR TITLE
Remove lxd charm jobs

### DIFF
--- a/config/jjb-templates/project-charm-lint-matrix.yaml
+++ b/config/jjb-templates/project-charm-lint-matrix.yaml
@@ -47,7 +47,6 @@
           - keystone
           - keystone-ldap
           - keystone-saml-mellon
-          - lxd
           - manila
           - manila-generic
           - masakari

--- a/config/jjb-templates/project-charm-pusher.yaml
+++ b/config/jjb-templates/project-charm-pusher.yaml
@@ -33,7 +33,6 @@
       - keystone
       - keystone-ldap
       - keystone-saml-mellon
-      - lxd
       - manila
       - manila-generic
       - masakari

--- a/config/jjb-templates/project-charm-single-matrix.yaml
+++ b/config/jjb-templates/project-charm-single-matrix.yaml
@@ -45,7 +45,6 @@
           - heat
           - keystone
           - keystone-ldap
-          - lxd
           - manila
           - manila-generic
           - masakari

--- a/config/jjb-templates/project-charm-unit-matrix.yaml
+++ b/config/jjb-templates/project-charm-unit-matrix.yaml
@@ -47,7 +47,6 @@
           - keystone
           - keystone-ldap
           - keystone-saml-mellon
-          - lxd
           - manila
           - manila-generic
           - masakari

--- a/config/jjb-templates/project-func-full-master-matrix.yaml
+++ b/config/jjb-templates/project-func-full-master-matrix.yaml
@@ -46,7 +46,6 @@
           - keystone
           - keystone-ldap
           - keystone-saml-mellon
-          - lxd
           - manila
           - manila-generic
           - masakari

--- a/config/jjb-templates/project-func-full-stable-matrix.yaml
+++ b/config/jjb-templates/project-func-full-stable-matrix.yaml
@@ -45,7 +45,6 @@
           - keystone
           - keystone-ldap
           - keystone-saml-mellon
-          - lxd
           - manila
           - manila-generic
           - masakari

--- a/config/jjb-templates/project-func-smoke-master-matrix.yaml
+++ b/config/jjb-templates/project-func-smoke-master-matrix.yaml
@@ -46,7 +46,6 @@
           - keystone
           - keystone-ldap
           - keystone-saml-mellon
-          - lxd
           - manila
           - manila-generic
           - masakari

--- a/config/jjb-templates/project-func-smoke-stable-matrix.yaml
+++ b/config/jjb-templates/project-func-smoke-stable-matrix.yaml
@@ -45,7 +45,6 @@
           - keystone
           - keystone-ldap
           - keystone-saml-mellon
-          - lxd
           - manila
           - manila-generic
           - masakari


### PR DESCRIPTION
The lxd charm (nova compute subordinate) is deprecated.  It's time to remove the charm jobs.