### PR TITLE
Skip watcher charm as it does not support xenial

### DIFF
--- a/config/charm-single/watcher.skip
+++ b/config/charm-single/watcher.skip
@@ -1,0 +1,1 @@
+# Skip watcher charm as it does not support xenial


### PR DESCRIPTION
UOSCI assumes all charms support Xenial so skip for the time being.