### PR TITLE
disable all charm pusher jobs

### DIFF
--- a/config/jjb-templates/project-charm-pusher.yaml
+++ b/config/jjb-templates/project-charm-pusher.yaml
@@ -78,6 +78,7 @@
 - job-template:
     name: 'charm_pusher_{charm}_master'
     node: task
+    disabled: true
     parameters:
         - string:
             name: BASE_NAME
@@ -118,6 +119,7 @@
 - job-template:
     name: 'charm_pusher_{charm}_stable'
     node: task
+    disabled: true
     parameters:
         - string:
             name: BASE_NAME


### PR DESCRIPTION
charm store update causing problems with granting acls - disabling charm pusher jobs.