### PR TITLE
Use opendev.org for charm pusher

### DIFF
--- a/config/jjb-templates/project-charm-pusher.yaml
+++ b/config/jjb-templates/project-charm-pusher.yaml
@@ -102,7 +102,7 @@
           artifact-num-to-keep: ''
     scm:
       - git:
-         url: https://github.com/openstack/charm-{charm}
+         url: https://opendev.org/openstack/charm-{charm}
          basedir: '{charm}'
          skip-tag: true
          fastpoll: true
@@ -143,7 +143,7 @@
           artifact-num-to-keep: ''
     scm:
       - git:
-         url: https://github.com/openstack/charm-{charm}
+         url: https://opendev.org/openstack/charm-{charm}
          basedir: '{charm}'
          skip-tag: true
          fastpoll: true


### PR DESCRIPTION
Push charm changes directly from opendev.org rather than relying on the github mirror process.