### PR TITLE
lolo-log-puller: Fix 'Failed to get logs from application unit'

### DIFF
--- a/tools/lib/common/tools_common.py
+++ b/tools/lib/common/tools_common.py
@@ -428,7 +428,7 @@ def run_cmds(cmds, fatal=False, stop_on_first_fail=True,
             ret = 0
         else:
             # Use os.system instead of subprocess due to piping and redirection
-            ret = os.system(cmd)
+            ret = os.system(cmd) >> 8
             logging.info('cmd [returned {}]: {}'.format(ret, cmd))
 
         if fatal and ret:


### PR DESCRIPTION
Often we can't investigate CI failures like [this one](http://osci:8080/view/MojoMatrix/job/mojo_runner/22611/console) because `lolo-log-puller` fails to fetch the logs of the corresponding unit:

```
01:53:48 ERROR:root:Failed to get logs from application unit: keystone/1
01:53:54 INFO:root:cmd [returned 256]: juju ssh keystone/2 "
01:53:54 dpkg -l | bzip2 -9z > /home/ubuntu/keystone-2-dpkg-list.bz2 &&
01:53:54 [[ -d /var/lib/charm ]] && sudo tar -cjf /home/ubuntu/keystone-2-var-lib-charm.tar.bz2 /var/lib/charm ||: &&
01:53:54 ps aux | bzip2 -9z > /home/ubuntu/keystone-2-processes.bz2 &&
01:53:54 sudo netstat -taupn | grep LISTEN | bzip2 -9z > /home/ubuntu/keystone-2-listening.bz2 &&
01:53:54 sudo ip a > /home/ubuntu/keystone-2-ip-addr.txt &&
01:53:54 df -h | bzip2 -9z > /home/ubuntu/keystone-2-df.bz2 &&
01:53:54 free -m | bzip2 -9z > /home/ubuntu/keystone-2-free.bz2 &&
01:53:54 sudo tar -cjf /home/ubuntu/keystone-2-var-log.tar.bz2 /var/log --warning=no-file-changed &&
01:53:54 sudo tar -cjf /home/ubuntu/keystone-2-etc.tar.bz2 /etc --warning=no-file-changed --exclude="/etc/X11" --exclude="/etc/ssl" --exclude="/etc/ssh" --exclude="shadow"
01:53:54 " >/dev/null 2>&1
```

This PR makes it more robust and verbose on failure.