### PR TITLE
Skip charm single test for ceph iscsi

### DIFF
--- a/config/charm-single/ceph-iscsi.skip
+++ b/config/charm-single/ceph-iscsi.skip
@@ -1,0 +1,4 @@
+# The ceph-iscsi charm does not have `xenial` series support and the
+# `charm-single` job assumes every charm does.
+#
+# https://bugs.launchpad.net/ubuntu-openstack-ci/+bug/1799376


### PR DESCRIPTION
Skip charm single test for ceph iscsi as it does not have xenial
support.