### PR TITLE
Skip charm single test for keystone-kerberos

### DIFF
--- a/config/charm-single/keystone-kerberos.skip
+++ b/config/charm-single/keystone-kerberos.skip
@@ -1,0 +1,4 @@
+# The keystone-kerberos charm does not have `xenial` series support and the
+# `charm-single` job assumes every charm does.
+#
+# https://bugs.launchpad.net/ubuntu-openstack-ci/+bug/1799376


### PR DESCRIPTION
Skip charm single test for keystone-kerberos as it does not have xenial
support.