### PR TITLE
Reduce parallelism

### DIFF
--- a/config/jjb-templates/jjb-run.sh
+++ b/config/jjb-templates/jjb-run.sh
@@ -8,8 +8,8 @@ stat -t .tox/jjb/bin/activate ||\
 . jjbrc
 
 # Build everything
-time jenkins-jobs --conf jjb-run.conf update --workers 16 .
+time jenkins-jobs --conf jjb-run.conf update .
 
 # Other examples for limiting
-# time jenkins-jobs --conf jjb-run.conf update --workers 16 . charm_push*
-# time jenkins-jobs --conf jjb-run.conf update --workers 16 . bundle-*
+# time jenkins-jobs --conf jjb-run.conf update . charm_push*
+# time jenkins-jobs --conf jjb-run.conf update . bundle-*


### PR DESCRIPTION
The default number of workers is 1. With 1 worker the execution time
is less than a minute, which is acceptable. Running with 16 workers
rarely works, even from a bastion.