### PR TITLE
add mattermost publisher to pusher jobs

### DIFF
--- a/config/jjb-templates/defaults-common.yaml
+++ b/config/jjb-templates/defaults-common.yaml
@@ -44,6 +44,29 @@
             presend-script: $DEFAULT_PRESEND_SCRIPT
             save-output: false
 
+- publisher:
+    name: mattermost_qa
+    publishers:
+        - raw:
+            xml: |
+              <jenkins.plugins.mattermost.MattermostNotifier plugin="mattermost@3.1.0">
+              <endpoint />
+              <room />
+              <icon />
+              <startNotification>false</startNotification>
+              <notifySuccess>false</notifySuccess>
+              <notifyAborted>false</notifyAborted>
+              <notifyNotBuilt>false</notifyNotBuilt>
+              <notifyUnstable>false</notifyUnstable>
+              <notifyFailure>true</notifyFailure>
+              <notifyBackToNormal>false</notifyBackToNormal>
+              <notifyRepeatedFailure>false</notifyRepeatedFailure>
+              <includeTestSummary>false</includeTestSummary>
+              <commitInfoChoice>NONE</commitInfoChoice>
+              <includeCustomAttachmentMessage>false</includeCustomAttachmentMessage>
+              <includeCustomMessage>false</includeCustomMessage>
+              </jenkins.plugins.mattermost.MattermostNotifier>
+
 - parameter:
     name: DISPLAY_NAME
     parameters:

--- a/config/jjb-templates/project-charm-pusher-x.yaml
+++ b/config/jjb-templates/project-charm-pusher-x.yaml
@@ -59,6 +59,7 @@
     publishers:
         - archive_artifacts
         - email_watchers
+        - mattermost_qa
 
 # STABLE
 - job-template:
@@ -100,3 +101,5 @@
     publishers:
         - archive_artifacts
         - email_watchers
+        - mattermost_qa
+

--- a/config/jjb-templates/project-charm-pusher.yaml
+++ b/config/jjb-templates/project-charm-pusher.yaml
@@ -120,6 +120,7 @@
     publishers:
         - archive_artifacts
         - email_watchers
+        - mattermost_qa
 
 # STABLE
 - job-template:
@@ -161,6 +162,7 @@
     publishers:
         - archive_artifacts
         - email_watchers
+        - mattermost_qa
 
 # NO-OP DEBUG JOB
 - job-template:


### PR DESCRIPTION
once we have the mattermost plugin installed this will send pusher failure notices to the qa channel on mattermost