### PR TITLE
The three targets listed have a new model alias now

### DIFF
--- a/config/jjb-templates/project-distro-regression-matrix.yaml
+++ b/config/jjb-templates/project-distro-regression-matrix.yaml
@@ -21,9 +21,9 @@
            - keystone_v3_smoke:xenial-queens
            - keystone_v3_smoke:bionic-queens
            - keystone_v3_smoke_rocky:bionic-rocky
-           - keystone_v3_smoke:bionic-stein
-           - keystone_v3_smoke:bionic-train
-           - keystone_v3_smoke:bionic-ussuri
+           - keystone_v3_smoke_stein:bionic-stein
+           - keystone_v3_smoke_stein:bionic-train
+           - keystone_v3_smoke_stein:bionic-ussuri
            - keystone_v3_smoke_focal:focal-ussuri
            - keystone_v3_smoke_focal:focal-victoria
            - keystone_v3_smoke_focal:groovy-victoria


### PR DESCRIPTION
In the process of adding Octavia to the distro-regression tests,
it became necessary to add a new model alias that describes the
version combinations where Octavia is deployed so that wee can
configure accordingly.