### PR TITLE
Remove eoan-train from ceph matrix

### DIFF
--- a/config/jjb-templates/project-mojo-matrix.yaml
+++ b/config/jjb-templates/project-mojo-matrix.yaml
@@ -920,7 +920,6 @@
           - "bionic-rocky"
           - "bionic-stein"
           - "bionic-train"
-          - "eoan-train"
     builders:
       - trigger-builds:
         - project:


### PR DESCRIPTION
`eoan-train` leads to [provisioning errors](http://osci:8080/job/mojo_runner/23816/console).