### PR TITLE
Fix "ImportError: No module named 'dogpile'"

### DIFF
--- a/tools/README.openstack-client-venv.md
+++ b/tools/README.openstack-client-venv.md
@@ -21,7 +21,9 @@ Alternatively, or perhaps more traditionally, one can just:
 cd /tmp
 virtualenv openstack-client
 . openstack-client/bin/activate
-pip install python-openstackclient
+
+# Newer versions dropped Python 3.5 support:
+pip install "python-openstackclient<3.19.0" "dogpile.cache<1.0.0"
+
 openstack --version
 ```
-

--- a/tools/openstack-client-venv/requirements.txt
+++ b/tools/openstack-client-venv/requirements.txt
@@ -1,2 +1,6 @@
-python-openstackclient
-python-neutronclient
+# Newer versions dropped Python 3.5 support:
+python-openstackclient<3.19.0
+python-neutronclient<6.13.0
+
+# Missing dependency of python-openstackclient:
+dogpile.cache<1.0.0

--- a/tools/port-cleanup-requirements.txt
+++ b/tools/port-cleanup-requirements.txt
@@ -1,11 +1,17 @@
 # one of the dependencies include openstacksdk and a dependency of
 # openstacksdk 0.44 dropped Python 3.5 support
 openstacksdk<0.44
-python-openstackclient
-python-neutronclient
-python-novaclient
-python-keystoneclient
-python-glanceclient
+
+# Newer versions dropped Python 3.5 support:
+python-openstackclient<3.19.0
+python-neutronclient<6.13.0
+python-novaclient<14.0.0
+python-keystoneclient<3.20.0
+python-glanceclient<2.17.0
+
+# Missing dependency of python-openstackclient:
+dogpile.cache<1.0.0
+
 jinja2
 
 # Newer versions use keywords that didn't exist in

--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -12,4 +12,3 @@ Jinja2>=2.6  # BSD License (3 clause)
 #six>=1.9.0
 #dnspython>=1.12.0
 #psutil>=1.1.1,<2.0.0
-#python-keystoneclient>=1.6.0,!=1.8.0


### PR DESCRIPTION
Without this change we get

```
port-cleanup installdeps: -r/var/lib/jenkins/tools/0/bot-control/tools/port-cleanup-requirements.txt
port-cleanup installed: You are using pip version 8.1.1, however version 20.3.1 is available.,You should consider upgrading via the 'pip install --upgrade pip' command.,appdirs==1.4.4,attrs==20.3.0,certifi==2020.11.8,cffi==1.14.4,chardet==3.0.4,cliff==3.5.0,cmd2==1.4.0,colorama==0.4.4,cryptography==3.2.1,debtcollector==2.2.0,decorator==4.4.2,idna==2.10,importlib-metadata==2.1.1,importlib-resources==2.0.1,iso8601==0.1.13,Jinja2==2.11.2,jmespath==0.10.0,jsonpatch==1.28,jsonpointer==2.0,jsonschema==3.2.0,keystoneauth1==4.3.0,MarkupSafe==1.1.1,msgpack==1.0.0,munch==2.5.0,netaddr==0.8.0,netifaces==0.10.9,openstacksdk==0.43.0,os-client-config==2.1.0,os-service-types==1.7.0,osc-lib==2.3.0,oslo.config==8.4.0,oslo.context==3.1.1,oslo.i18n==5.0.1,oslo.log==4.4.0,oslo.serialization==4.0.1,oslo.utils==4.7.0,packaging==20.7,pbr==5.5.1,pkg-resources==0.0.0,prettytable==0.7.2,pycparser==2.20,pyinotify==0.9.6,pyOpenSSL==20.0.0,pyparsing==2.4.7,pyperclip==1.8.1,pyrsistent==0.17.3,python-cinderclient==7.2.0,python-dateutil==2.8.1,python-glanceclient==3.2.2,python-keystoneclient==4.2.0,python-neutronclient==7.2.1,python-novaclient==17.2.1,python-openstackclient==5.4.0,pytz==2020.4,PyYAML==5.3.1,requests==2.25.0,requestsexceptions==1.4.0,rfc3986==1.4.0,simplejson==3.17.2,six==1.15.0,stevedore==3.3.0,UNKNOWN==0.0.0,urllib3==1.26.2,warlock==1.3.3,wcwidth==0.2.5,wrapt==1.12.1,zipp==3.4.0
port-cleanup run-test-pre: PYTHONHASHSEED='0'
port-cleanup run-test: commands[0] | openstack --version
Traceback (most recent call last):
  File "/var/lib/jenkins/tools/0/bot-control/tools/.tox/port-cleanup/bin/openstack", line 7, in <module>
    from openstackclient.shell import main
  File "/var/lib/jenkins/tools/0/bot-control/tools/.tox/port-cleanup/lib/python3.5/site-packages/openstackclient/shell.py", line 24, in <module>
    from osc_lib import shell
  File "/var/lib/jenkins/tools/0/bot-control/tools/.tox/port-cleanup/lib/python3.5/site-packages/osc_lib/shell.py", line 32, in <module>
    from osc_lib.cli import client_config as cloud_config
  File "/var/lib/jenkins/tools/0/bot-control/tools/.tox/port-cleanup/lib/python3.5/site-packages/osc_lib/cli/client_config.py", line 18, in <module>
    from openstack.config import exceptions as sdk_exceptions
  File "/var/lib/jenkins/tools/0/bot-control/tools/.tox/port-cleanup/lib/python3.5/site-packages/openstack/__init__.py", line 17, in <module>
    import openstack.connection
  File "/var/lib/jenkins/tools/0/bot-control/tools/.tox/port-cleanup/lib/python3.5/site-packages/openstack/connection.py", line 188, in <module>
    from openstack.cloud import openstackcloud as _cloud
  File "/var/lib/jenkins/tools/0/bot-control/tools/.tox/port-cleanup/lib/python3.5/site-packages/openstack/cloud/openstackcloud.py", line 21, in <module>
    import dogpile.cache
ImportError: No module named 'dogpile'
ERROR: InvocationError for command /var/lib/jenkins/tools/0/bot-control/tools/.tox/port-cleanup/bin/openstack --version (exited with code 1)
```

https://openstack-ci-reports.ubuntu.com/artifacts/test_charm_pipeline_func_smoke/openstack/charm-ceph-radosgw/764641/16/20374/consoleText.test_charm_single_119537.txt

I was able to reproduce and fix it locally:

```
cd tools/
tox -e port-cleanup
```