### PR TITLE
Fix lolo-log-puller dependency

### DIFF
--- a/tools/port-cleanup-requirements.txt
+++ b/tools/port-cleanup-requirements.txt
@@ -9,6 +9,9 @@ python-novaclient<14.0.0
 python-keystoneclient<3.20.0
 python-glanceclient<2.17.0
 
+# Dependency of python-glanceclient. Newer versions dropped Python 3.5 support:
+oslo.utils<=3.41.0
+
 # Missing dependency of python-openstackclient:
 dogpile.cache<1.0.0
 


### PR DESCRIPTION
Before this change

```
cd tools/
tox -e port-cleanup
. .tox/port-cleanup/bin/activate
./lolo-log-puller
```

failed with

```
13:37:05 Traceback (most recent call last):
13:37:05   File "/var/lib/jenkins/tools/0/bot-control/tools/lolo-log-puller", line 19, in <module>
13:37:05     from lolo_log_puller import lolo_log_puller_cli
13:37:05   File "/var/lib/jenkins/tools/0/bot-control/tools/lib/lolo_log_puller/lolo_log_puller_cli.py", line 22, in <module>
13:37:05     import common.tools_common as u
13:37:05   File "/var/lib/jenkins/tools/0/bot-control/tools/lib/common/tools_common.py", line 37, in <module>
13:37:05     import glanceclient.v1.client as glanceclient
13:37:05   File "/var/lib/jenkins/tools/0/bot-control/tools/.tox/port-cleanup/lib/python3.5/site-packages/glanceclient/v1/__init__.py", line 16, in <module>
13:37:05     from glanceclient.v1.client import Client      # noqa
13:37:05   File "/var/lib/jenkins/tools/0/bot-control/tools/.tox/port-cleanup/lib/python3.5/site-packages/glanceclient/v1/client.py", line 16, in <module>
13:37:05     from glanceclient.common import http
13:37:05   File "/var/lib/jenkins/tools/0/bot-control/tools/.tox/port-cleanup/lib/python3.5/site-packages/glanceclient/common/http.py", line 24, in <module>
13:37:05     from oslo_utils import netutils
13:37:05   File "/var/lib/jenkins/tools/0/bot-control/tools/.tox/port-cleanup/lib/python3.5/site-packages/oslo_utils/netutils.py", line 217
13:37:05     (((ipv6 & 0xff_ff_ff_00_00_00_00_00) >> 16) +
13:37:05                                       ^
13:37:05 SyntaxError: invalid syntax
```

http://osci:8080/job/test_charm_single/119553/console