### PR TITLE
Pin mock and OpenStack clients only on Python 3.5

### DIFF
--- a/tools/openstack-client-venv/requirements.txt
+++ b/tools/openstack-client-venv/requirements.txt
@@ -1,6 +1,8 @@
 # Newer versions dropped Python 3.5 support:
-python-openstackclient<3.19.0
-python-neutronclient<6.13.0
+python-openstackclient<3.19.0; python_version < '3.6'
+python-openstackclient; python_version >= '3.6'
+python-neutronclient<6.13.0; python_version < '3.6'
+python-neutronclient; python_version >= '3.6'
 
 # Missing dependency of python-openstackclient:
-dogpile.cache<1.0.0
+dogpile.cache<1.0.0; python_version < '3.6'

--- a/tools/port-cleanup-requirements.txt
+++ b/tools/port-cleanup-requirements.txt
@@ -3,21 +3,26 @@
 openstacksdk<0.44
 
 # Newer versions dropped Python 3.5 support:
-python-openstackclient<3.19.0
-python-neutronclient<6.13.0
-python-novaclient<14.0.0
-python-keystoneclient<3.20.0
-python-glanceclient<2.17.0
+python-openstackclient<3.19.0; python_version < '3.6'
+python-openstackclient; python_version >= '3.6'
+python-neutronclient<6.13.0; python_version < '3.6'
+python-neutronclient; python_version >= '3.6'
+python-novaclient<14.0.0; python_version < '3.6'
+python-novaclient; python_version >= '3.6'
+python-keystoneclient<3.20.0; python_version < '3.6'
+python-keystoneclient; python_version >= '3.6'
+python-glanceclient<2.17.0; python_version < '3.6'
+python-glanceclient; python_version >= '3.6'
 
 # Dependency of python-glanceclient. Newer versions dropped Python 3.5 support:
-oslo.utils<=3.41.0
+oslo.utils<=3.41.0; python_version < '3.6'
 
 # Missing dependency of python-openstackclient:
-dogpile.cache<1.0.0
+dogpile.cache<1.0.0; python_version < '3.6'
 
 jinja2
 
 # Newer versions use keywords that didn't exist in
 # python 3.5 yet (e.g. "ModuleNotFoundError")
-importlib-metadata<3.0.0
-importlib-resources<3.0.0
+importlib-metadata<3.0.0; python_version < '3.6'
+importlib-resources<3.0.0; python_version < '3.6'

--- a/tools/test-requirements.txt
+++ b/tools/test-requirements.txt
@@ -5,7 +5,8 @@ coverage>=3.6
 
 # Newer mock seems to have some syntax which is newer than python3.5 (e.g.
 # f'{something}'
-mock>=1.2,<4.0.0
+mock>=1.2,<4.0.0; python_version < '3.6'
+mock>=1.2; python_version >= '3.6'
 
 pep8>=1.7.0
 flake8>=2.2.4


### PR DESCRIPTION
Validated locally with:

```
cd tools/
tox -e port-cleanup
```
