### PR TITLE
Pin pip and virtualenv to <20.3 and <20.0

### DIFF
--- a/config/jjb-templates/tox.ini
+++ b/config/jjb-templates/tox.ini
@@ -1,6 +1,18 @@
 [tox]
 envlist = jjb
 skipsdist = True
+# NOTES:
+# * We avoid the new dependency resolver by pinning pip < 20.3, see
+#   https://github.com/pypa/pip/issues/9187
+# * Pinning dependencies requires tox >= 3.2.0, see
+#   https://tox.readthedocs.io/en/latest/config.html#conf-requires
+# * It is also necessary to pin virtualenv as a newer virtualenv would still
+#   lead to fetching the latest pip in the func* tox targets, see
+#   https://stackoverflow.com/a/38133283
+requires = pip < 20.3
+           virtualenv < 20.0
+# NOTE: https://wiki.canonical.com/engineering/OpenStack/InstallLatestToxOnOsci
+minversion = 3.2.0
 
 [testenv]
 setenv = VIRTUAL_ENV={envdir}

--- a/tools/openstack-client-venv/tox.ini
+++ b/tools/openstack-client-venv/tox.ini
@@ -1,6 +1,18 @@
 [tox]
 envlist = openstack-client
 skipsdist = True
+# NOTES:
+# * We avoid the new dependency resolver by pinning pip < 20.3, see
+#   https://github.com/pypa/pip/issues/9187
+# * Pinning dependencies requires tox >= 3.2.0, see
+#   https://tox.readthedocs.io/en/latest/config.html#conf-requires
+# * It is also necessary to pin virtualenv as a newer virtualenv would still
+#   lead to fetching the latest pip in the func* tox targets, see
+#   https://stackoverflow.com/a/38133283
+requires = pip < 20.3
+           virtualenv < 20.0
+# NOTE: https://wiki.canonical.com/engineering/OpenStack/InstallLatestToxOnOsci
+minversion = 3.2.0
 
 [testenv]
 setenv = VIRTUAL_ENV={envdir}

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,18 @@
 [tox]
 envlist = yaml_load,jjb_test
 skipsdist = True
+# NOTES:
+# * We avoid the new dependency resolver by pinning pip < 20.3, see
+#   https://github.com/pypa/pip/issues/9187
+# * Pinning dependencies requires tox >= 3.2.0, see
+#   https://tox.readthedocs.io/en/latest/config.html#conf-requires
+# * It is also necessary to pin virtualenv as a newer virtualenv would still
+#   lead to fetching the latest pip in the func* tox targets, see
+#   https://stackoverflow.com/a/38133283
+requires = pip < 20.3
+           virtualenv < 20.0
+# NOTE: https://wiki.canonical.com/engineering/OpenStack/InstallLatestToxOnOsci
+minversion = 3.2.0
 
 [testenv]
 basepython = python3


### PR DESCRIPTION
Also set the minimum version for tox to be 3.2.0.  This is to ensure
that a) we continue py27 compatibility, b) we don't introduce breaking
changes in pip (losing py35 on xenial) and c) the resolver continues to
work the way it used to whilst the technical debt is resolved in the
dependencies.