### PR TITLE
Restrict the amount of disk storage for jobs

### DIFF
--- a/config/jjb-templates/project-charm-build-matrix.yaml
+++ b/config/jjb-templates/project-charm-build-matrix.yaml
@@ -70,6 +70,12 @@
             - "charm_build"
           current-parameters: true
           block: true
+          properties:
+            - build-discarder:
+              days-to-keep: 90
+              num-to-keep: ''
+              artifact-days-to-keep: 90
+              artifact-num-to-keep: ''
           predefined-parameters: |
             BASE_NAME=$BASE_NAME
             GIT_BRANCH=$GIT_BRANCH

--- a/config/jjb-templates/project-charm-lint-matrix.yaml
+++ b/config/jjb-templates/project-charm-lint-matrix.yaml
@@ -96,6 +96,12 @@
             - "test_charm_lint"
           current-parameters: true
           block: true
+          properties:
+            - build-discarder:
+              days-to-keep: 90
+              num-to-keep: ''
+              artifact-days-to-keep: 90
+              artifact-num-to-keep: ''
           predefined-parameters: |
             BASE_NAME=$BASE_NAME
             GIT_BRANCH=$GIT_BRANCH

--- a/config/jjb-templates/project-charm-pusher-x.yaml
+++ b/config/jjb-templates/project-charm-pusher-x.yaml
@@ -37,6 +37,8 @@
         - DISPLAY_NAME
     properties:
       - build-discarder:
+          days-to-keep: 90
+          num-to-keep: ''
           artifact-days-to-keep: 3
           artifact-num-to-keep: ''
     scm:
@@ -78,6 +80,8 @@
         - DISPLAY_NAME
     properties:
       - build-discarder:
+          days-to-keep: 90
+          num-to-keep: ''
           artifact-days-to-keep: 3
           artifact-num-to-keep: ''
     scm:

--- a/config/jjb-templates/project-charm-pusher.yaml
+++ b/config/jjb-templates/project-charm-pusher.yaml
@@ -105,6 +105,8 @@
         - DISPLAY_NAME
     properties:
       - build-discarder:
+          days-to-keep: 90
+          num-to-keep: ''
           artifact-days-to-keep: 3
           artifact-num-to-keep: ''
     scm:
@@ -146,6 +148,8 @@
         - DISPLAY_NAME
     properties:
       - build-discarder:
+          days-to-keep: 90
+          num-to-keep: ''
           artifact-days-to-keep: 3
           artifact-num-to-keep: ''
     scm:
@@ -186,6 +190,8 @@
         - DISPLAY_NAME
     properties:
       - build-discarder:
+          days-to-keep: 90
+          num-to-keep: ''
           artifact-days-to-keep: 3
           artifact-num-to-keep: ''
     scm:

--- a/config/jjb-templates/project-charm-single-matrix.yaml
+++ b/config/jjb-templates/project-charm-single-matrix.yaml
@@ -8,6 +8,12 @@
     execution-strategy:
       sequential: true
     node: task
+    properties:
+      - build-discarder:
+          days-to-keep: 90
+          num-to-keep: ''
+          artifact-days-to-keep: 3
+          artifact-num-to-keep: ''
     triggers:
         - timed: "H H(0-6) * * *"  # Daily in the wee hours
     axes:

--- a/config/jjb-templates/project-charm-unit-matrix.yaml
+++ b/config/jjb-templates/project-charm-unit-matrix.yaml
@@ -8,6 +8,12 @@
     execution-strategy:
       sequential: true
     node: task
+    properties:
+      - build-discarder:
+          days-to-keep: 90
+          num-to-keep: ''
+          artifact-days-to-keep: 3
+          artifact-num-to-keep: ''
     triggers:
         - timed: "H H(0-6) * * *"  # Daily in the wee hours
     axes:

--- a/config/jjb-templates/project-func-full-master-matrix.yaml
+++ b/config/jjb-templates/project-func-full-master-matrix.yaml
@@ -8,6 +8,12 @@
     execution-strategy:
       sequential: true
     node: task
+    properties:
+      - build-discarder:
+          days-to-keep: 90
+          num-to-keep: ''
+          artifact-days-to-keep: 3
+          artifact-num-to-keep: ''
     triggers:
         - timed: ""  # No schedule, leaving in place for manual trigger.
     axes:

--- a/config/jjb-templates/project-func-full-stable-matrix.yaml
+++ b/config/jjb-templates/project-func-full-stable-matrix.yaml
@@ -8,6 +8,12 @@
     execution-strategy:
       sequential: true
     node: task
+    properties:
+      - build-discarder:
+          days-to-keep: 90
+          num-to-keep: ''
+          artifact-days-to-keep: 3
+          artifact-num-to-keep: ''
     triggers:
         - timed: ""  # No schedule, leaving in place for manual trigger.
     axes:

--- a/config/jjb-templates/project-func-smoke-master-matrix.yaml
+++ b/config/jjb-templates/project-func-smoke-master-matrix.yaml
@@ -8,6 +8,12 @@
     execution-strategy:
       sequential: true
     node: task
+    properties:
+      - build-discarder:
+          days-to-keep: 90
+          num-to-keep: ''
+          artifact-days-to-keep: 3
+          artifact-num-to-keep: ''
     triggers:
         - timed: ""  # No schedule, leaving in place for manual trigger.
     axes:

--- a/config/jjb-templates/project-func-smoke-stable-matrix.yaml
+++ b/config/jjb-templates/project-func-smoke-stable-matrix.yaml
@@ -8,6 +8,12 @@
     execution-strategy:
       sequential: true
     node: task
+    properties:
+      - build-discarder:
+          days-to-keep: 90
+          num-to-keep: ''
+          artifact-days-to-keep: 3
+          artifact-num-to-keep: ''
     triggers:
         - timed: ""  # No schedule, leaving in place for manual trigger.
     axes:

--- a/config/jjb-templates/project-mojo-matrix.yaml
+++ b/config/jjb-templates/project-mojo-matrix.yaml
@@ -674,6 +674,8 @@
     concurrent: true
     properties:
       - build-discarder:
+          days-to-keep: 90
+          num-to-keep: ''
           artifact-days-to-keep: 3
           artifact-num-to-keep: ''
       - throttle:

--- a/tox.ini
+++ b/tox.ini
@@ -29,4 +29,4 @@ commands = bash -ex tests/validate_yaml_load.sh
 
 [testenv:jjb_test]
 deps = -r{toxinidir}/config/jjb-templates/jjb-requirements.txt
-commands = jenkins-jobs --conf config/jjb-templates/jjb-ci.conf --ignore-cache test config/jjb-templates
+commands = jenkins-jobs -l debug --conf config/jjb-templates/jjb-ci.conf --ignore-cache test config/jjb-templates


### PR DESCRIPTION
This PR limits the number of days to keep jobs in Jenkins to 90 days
(one development cycle on average).  This is to reduce the disk usage,
but more importantly, number of builds.  The larger the number of builds
the more CPU Jenkins uses and this slows down the UI.