### PR TITLE
Attempt to fix retention times on Jenkins (part 2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 *.sw[nop]
 *.pyc
 jjb-run.conf
+config/jjb-templates/output.txt

--- a/config/jjb-templates/jjb-devel.sh
+++ b/config/jjb-templates/jjb-devel.sh
@@ -1,0 +1,14 @@
+#!/bin/bash -ex
+# Perform a no-op test exercise of the jenkins job builder definitions
+
+stat -t .tox/jjb/bin/activate ||\
+    tox
+
+. jjbrc
+
+outfile="./output.txt"
+
+time jenkins-jobs --conf jjb-run.conf test . &> $outfile
+grep "jenkins_jobs" $outfile
+
+echo "Examine $outfile for details"

--- a/config/jjb-templates/project-charm-build-matrix.yaml
+++ b/config/jjb-templates/project-charm-build-matrix.yaml
@@ -10,6 +10,11 @@
     node: task
     triggers:
         - timed: ""  # No schedule, leaving in place for manual trigger.
+
+    properties:
+      - build-discarder:
+          days-to-keep: 90
+          num-to-keep: ''
     axes:
       - axis:
          type: user-defined
@@ -70,12 +75,6 @@
             - "charm_build"
           current-parameters: true
           block: true
-          properties:
-            - build-discarder:
-              days-to-keep: 90
-              num-to-keep: ''
-              artifact-days-to-keep: 90
-              artifact-num-to-keep: ''
           predefined-parameters: |
             BASE_NAME=$BASE_NAME
             GIT_BRANCH=$GIT_BRANCH

--- a/config/jjb-templates/project-charm-pusher.yaml
+++ b/config/jjb-templates/project-charm-pusher.yaml
@@ -107,8 +107,6 @@
       - build-discarder:
           days-to-keep: 90
           num-to-keep: ''
-          artifact-days-to-keep: 3
-          artifact-num-to-keep: ''
     scm:
       - git:
          url: https://opendev.org/openstack/charm-{charm}
@@ -150,8 +148,6 @@
       - build-discarder:
           days-to-keep: 90
           num-to-keep: ''
-          artifact-days-to-keep: 3
-          artifact-num-to-keep: ''
     scm:
       - git:
          url: https://opendev.org/openstack/charm-{charm}
@@ -192,8 +188,6 @@
       - build-discarder:
           days-to-keep: 90
           num-to-keep: ''
-          artifact-days-to-keep: 3
-          artifact-num-to-keep: ''
     scm:
       - git:
          url: https://github.com/ryan-beisner/trigger-test

--- a/config/jjb-templates/project-func-full-master-matrix.yaml
+++ b/config/jjb-templates/project-func-full-master-matrix.yaml
@@ -12,8 +12,6 @@
       - build-discarder:
           days-to-keep: 90
           num-to-keep: ''
-          artifact-days-to-keep: 3
-          artifact-num-to-keep: ''
     triggers:
         - timed: ""  # No schedule, leaving in place for manual trigger.
     axes:

--- a/config/jjb-templates/project-func-full-stable-matrix.yaml
+++ b/config/jjb-templates/project-func-full-stable-matrix.yaml
@@ -12,8 +12,6 @@
       - build-discarder:
           days-to-keep: 90
           num-to-keep: ''
-          artifact-days-to-keep: 3
-          artifact-num-to-keep: ''
     triggers:
         - timed: ""  # No schedule, leaving in place for manual trigger.
     axes:

--- a/config/jjb-templates/project-func-smoke-master-matrix.yaml
+++ b/config/jjb-templates/project-func-smoke-master-matrix.yaml
@@ -12,8 +12,6 @@
       - build-discarder:
           days-to-keep: 90
           num-to-keep: ''
-          artifact-days-to-keep: 3
-          artifact-num-to-keep: ''
     triggers:
         - timed: ""  # No schedule, leaving in place for manual trigger.
     axes:

--- a/config/jjb-templates/project-func-smoke-stable-matrix.yaml
+++ b/config/jjb-templates/project-func-smoke-stable-matrix.yaml
@@ -12,8 +12,6 @@
       - build-discarder:
           days-to-keep: 90
           num-to-keep: ''
-          artifact-days-to-keep: 3
-          artifact-num-to-keep: ''
     triggers:
         - timed: ""  # No schedule, leaving in place for manual trigger.
     axes:

--- a/config/jjb-templates/project-mojo-matrix.yaml
+++ b/config/jjb-templates/project-mojo-matrix.yaml
@@ -676,8 +676,6 @@
       - build-discarder:
           days-to-keep: 90
           num-to-keep: ''
-          artifact-days-to-keep: 3
-          artifact-num-to-keep: ''
       - throttle:
           max-per-node: 1
           max-total: 4


### PR DESCRIPTION
This is the 2nd attempt to fix the retention times of jobs on Jenkins.
This is to attempt to reduce the CPU utilisation that it uses, as it is
proportional to the number of jobs that it has in the jobs/ directory
(apparently!)