### PR TITLE
num-to-keep: '' causes 0 jobs to be kept rather than inf

### DIFF
--- a/config/jjb-templates/project-charm-build-matrix.yaml
+++ b/config/jjb-templates/project-charm-build-matrix.yaml
@@ -14,7 +14,6 @@
     properties:
       - build-discarder:
           days-to-keep: 90
-          num-to-keep: ''
     axes:
       - axis:
          type: user-defined

--- a/config/jjb-templates/project-charm-lint-matrix.yaml
+++ b/config/jjb-templates/project-charm-lint-matrix.yaml
@@ -103,9 +103,6 @@
           properties:
             - build-discarder:
               days-to-keep: 90
-              num-to-keep: ''
-              artifact-days-to-keep: 90
-              artifact-num-to-keep: ''
           predefined-parameters: |
             BASE_NAME=$BASE_NAME
             GIT_BRANCH=$GIT_BRANCH

--- a/config/jjb-templates/project-charm-pusher-x.yaml
+++ b/config/jjb-templates/project-charm-pusher-x.yaml
@@ -38,9 +38,7 @@
     properties:
       - build-discarder:
           days-to-keep: 90
-          num-to-keep: ''
           artifact-days-to-keep: 3
-          artifact-num-to-keep: ''
     scm:
       - git:
          url: https://opendev.org/x/charm-{charm}
@@ -81,9 +79,6 @@
     properties:
       - build-discarder:
           days-to-keep: 90
-          num-to-keep: ''
-          artifact-days-to-keep: 3
-          artifact-num-to-keep: ''
     scm:
       - git:
          url: https://opendev.org/x/charm-{charm}

--- a/config/jjb-templates/project-charm-pusher.yaml
+++ b/config/jjb-templates/project-charm-pusher.yaml
@@ -110,7 +110,6 @@
     properties:
       - build-discarder:
           days-to-keep: 90
-          num-to-keep: ''
     scm:
       - git:
          url: https://opendev.org/openstack/charm-{charm}
@@ -151,7 +150,6 @@
     properties:
       - build-discarder:
           days-to-keep: 90
-          num-to-keep: ''
     scm:
       - git:
          url: https://opendev.org/openstack/charm-{charm}
@@ -191,7 +189,6 @@
     properties:
       - build-discarder:
           days-to-keep: 90
-          num-to-keep: ''
     scm:
       - git:
          url: https://github.com/ryan-beisner/trigger-test

--- a/config/jjb-templates/project-charm-single-matrix.yaml
+++ b/config/jjb-templates/project-charm-single-matrix.yaml
@@ -11,9 +11,6 @@
     properties:
       - build-discarder:
           days-to-keep: 90
-          num-to-keep: ''
-          artifact-days-to-keep: 3
-          artifact-num-to-keep: ''
     triggers:
         - timed: "H H(0-6) * * *"  # Daily in the wee hours
     axes:

--- a/config/jjb-templates/project-charm-unit-matrix.yaml
+++ b/config/jjb-templates/project-charm-unit-matrix.yaml
@@ -11,9 +11,6 @@
     properties:
       - build-discarder:
           days-to-keep: 90
-          num-to-keep: ''
-          artifact-days-to-keep: 3
-          artifact-num-to-keep: ''
     triggers:
         - timed: "H H(0-6) * * *"  # Daily in the wee hours
     axes:

--- a/config/jjb-templates/project-distro-regression-matrix.yaml
+++ b/config/jjb-templates/project-distro-regression-matrix.yaml
@@ -50,7 +50,6 @@
     properties:
       - build-discarder:
           artifact-days-to-keep: 3
-          artifact-num-to-keep: ''
       - throttle:
           max-per-node: 1
           max-total: 2

--- a/config/jjb-templates/project-func-full-master-matrix.yaml
+++ b/config/jjb-templates/project-func-full-master-matrix.yaml
@@ -11,7 +11,6 @@
     properties:
       - build-discarder:
           days-to-keep: 90
-          num-to-keep: ''
     triggers:
         - timed: ""  # No schedule, leaving in place for manual trigger.
     axes:

--- a/config/jjb-templates/project-func-full-stable-matrix.yaml
+++ b/config/jjb-templates/project-func-full-stable-matrix.yaml
@@ -11,7 +11,6 @@
     properties:
       - build-discarder:
           days-to-keep: 90
-          num-to-keep: ''
     triggers:
         - timed: ""  # No schedule, leaving in place for manual trigger.
     axes:

--- a/config/jjb-templates/project-func-matrix.yaml
+++ b/config/jjb-templates/project-func-matrix.yaml
@@ -17,8 +17,7 @@
     concurrent: true
     properties:
       - build-discarder:
-          artifact-days-to-keep: 3
-          artifact-num-to-keep: ''
+          days-to-keep: 90
       - throttle:
           max-per-node: 1
           max-total: 3
@@ -79,8 +78,7 @@
     concurrent: true
     properties:
       - build-discarder:
-          artifact-days-to-keep: 3
-          artifact-num-to-keep: ''
+          days-to-keep: 90
       - throttle:
           max-per-node: 1
           max-total: 3

--- a/config/jjb-templates/project-func-smoke-master-matrix.yaml
+++ b/config/jjb-templates/project-func-smoke-master-matrix.yaml
@@ -11,7 +11,6 @@
     properties:
       - build-discarder:
           days-to-keep: 90
-          num-to-keep: ''
     triggers:
         - timed: ""  # No schedule, leaving in place for manual trigger.
     axes:

--- a/config/jjb-templates/project-func-smoke-stable-matrix.yaml
+++ b/config/jjb-templates/project-func-smoke-stable-matrix.yaml
@@ -11,7 +11,6 @@
     properties:
       - build-discarder:
           days-to-keep: 90
-          num-to-keep: ''
     triggers:
         - timed: ""  # No schedule, leaving in place for manual trigger.
     axes:

--- a/config/jjb-templates/project-mojo-matrix.yaml
+++ b/config/jjb-templates/project-mojo-matrix.yaml
@@ -675,7 +675,6 @@
     properties:
       - build-discarder:
           days-to-keep: 90
-          num-to-keep: ''
       - throttle:
           max-per-node: 1
           max-total: 4


### PR DESCRIPTION
This patch removes the "num-to-keep: ''" lines from the jjb-templates as
it results in 0 (zero) being used rather than not setting the value.
This causes jenkins to immediate delete the artifact.  This is a
problem.