### PR TITLE
Add charm pushers for stable/21.10 as candidate

### DIFF
--- a/config/jjb-templates/project-charm-pusher-x.yaml
+++ b/config/jjb-templates/project-charm-pusher-x.yaml
@@ -18,6 +18,7 @@
     jobs:
       - 'charm_pusher_x_{charm}_master'
       - 'charm_pusher_x_{charm}_stable'
+      - 'charm_pusher_x_{charm}_candidate'
 
 # MASTER
 - job-template:
@@ -33,6 +34,10 @@
             name: GIT_BRANCH
             default: master
             description: Git branch.  Generally master or stable/nn.nn.
+        - string:
+            name: JUJU_CHANNEL
+            default: candidate
+            description: The channel to push the charm to (stable, candidate, beta, edge)
         - CHARM_PUSH_DRY_RUN
         - DISPLAY_NAME
     properties:
@@ -74,6 +79,10 @@
             name: GIT_BRANCH
             default: stable/21.04
             description: Git branch.  Generally master or stable/nn.nn.
+        - string:
+            name: JUJU_CHANNEL
+            default: candidate
+            description: The channel to push the charm to (stable, candidate, beta, edge)
         - CHARM_PUSH_DRY_RUN
         - DISPLAY_NAME
     properties:
@@ -89,6 +98,50 @@
          clean: {before: true}
          branches:
           - stable/21.04
+    triggers:
+      - pollscm:
+          cron: 'H/10 * * * *'
+          ignore-post-commit-hooks: True
+    builders:
+      - prep_osci_repo_if_necessary
+      - build_charm_push_and_publish
+    publishers:
+        - archive_artifacts
+        - email_watchers
+
+# CANDIDATE
+- job-template:
+    name: 'charm_pusher_x_{charm}_candidate'
+    node: task
+    disabled: true
+    parameters:
+        - string:
+            name: BASE_NAME
+            default: '{charm}'
+            description: Asset name (charm name).
+        - string:
+            name: GIT_BRANCH
+            default: stable/21.10
+            description: Git branch.  Generally master or stable/nn.nn.
+        - string:
+            name: JUJU_CHANNEL
+            default: candidate
+            description: The channel to push the charm to (stable, candidate, beta, edge)
+        - CHARM_PUSH_DRY_RUN
+        - DISPLAY_NAME
+    properties:
+      - build-discarder:
+          days-to-keep: 90
+    scm:
+      - git:
+         url: https://opendev.org/x/charm-{charm}
+         basedir: '{charm}'
+         skip-tag: true
+         fastpoll: true
+         shallow-clone: true
+         clean: {before: true}
+         branches:
+          - stable/21.10
     triggers:
       - pollscm:
           cron: 'H/10 * * * *'

--- a/config/jjb-templates/project-charm-pusher.yaml
+++ b/config/jjb-templates/project-charm-pusher.yaml
@@ -88,6 +88,7 @@
     jobs:
       - 'charm_pusher_{charm}_master'
       - 'charm_pusher_{charm}_stable'
+      - 'charm_pusher_{charm}_candidate'
       - 'charm_pusher_noop_debug'
 
 # MASTER
@@ -104,6 +105,10 @@
             name: GIT_BRANCH
             default: master
             description: Git branch.  Generally master or stable/nn.nn.
+        - string:
+            name: JUJU_CHANNEL
+            default: stable
+            description: The channel to push the charm to (stable, candidate, beta, edge)
         - CHARM_PUSH_DRY_RUN
         - DISPLAY_NAME
     properties:
@@ -128,7 +133,7 @@
       - build_charm_push_and_publish
     publishers:
         - archive_artifacts
-        - email_watchers
+        #- email_watchers
 
 # STABLE
 - job-template:
@@ -144,6 +149,10 @@
             name: GIT_BRANCH
             default: stable/21.04
             description: Git branch.  Generally master or stable/nn.nn.
+        - string:
+            name: JUJU_CHANNEL
+            default: stable
+            description: The channel to push the charm to (stable, candidate, beta, edge)
         - CHARM_PUSH_DRY_RUN
         - DISPLAY_NAME
     properties:
@@ -168,7 +177,51 @@
       - build_charm_push_and_publish
     publishers:
         - archive_artifacts
-        - email_watchers
+        #- email_watchers
+
+# CANDIDATE
+- job-template:
+    name: 'charm_pusher_{charm}_candidate'
+    node: task
+    disabled: true
+    parameters:
+        - string:
+            name: BASE_NAME
+            default: '{charm}'
+            description: Asset name (charm name).
+        - string:
+            name: GIT_BRANCH
+            default: stable/21.10
+            description: Git branch.  Generally master or stable/nn.nn.
+        - string:
+            name: JUJU_CHANNEL
+            default: candidate
+            description: The channel to push the charm to (stable, candidate, beta, edge)
+        - CHARM_PUSH_DRY_RUN
+        - DISPLAY_NAME
+    properties:
+      - build-discarder:
+          days-to-keep: 90
+    scm:
+      - git:
+         url: https://opendev.org/openstack/charm-{charm}
+         basedir: '{charm}'
+         skip-tag: true
+         fastpoll: true
+         shallow-clone: true
+         clean: {before: true}
+         branches:
+          - stable/21.10
+    triggers:
+      - pollscm:
+          cron: 'H/10 * * * *'
+          ignore-post-commit-hooks: True
+    builders:
+      - prep_osci_repo_if_necessary
+      - build_charm_push_and_publish
+    publishers:
+        - archive_artifacts
+        #- email_watchers
 
 # NO-OP DEBUG JOB
 - job-template:
@@ -183,6 +236,10 @@
             name: GIT_BRANCH
             default: master
             description: Git branch.  Generally master or stable/nn.nn.
+        - string:
+            name: JUJU_CHANNEL
+            default: stable
+            description: The channel to push the charm to (stable, candidate, beta, edge)
         - CHARM_PUSH_DRY_RUN
         - DISPLAY_NAME
     properties:


### PR DESCRIPTION
This adds charm pushers for the openstack/ and x/ projects to push
stable/21.10 as the candidate channel to ~openstack-charmers/<charm>.
The jobs are initially disabled to prevent any untowards issues.