### PR TITLE
Fix the charm-pusher for x projects for stable

### DIFF
--- a/config/jjb-templates/project-charm-pusher-x.yaml
+++ b/config/jjb-templates/project-charm-pusher-x.yaml
@@ -36,7 +36,7 @@
             description: Git branch.  Generally master or stable/nn.nn.
         - string:
             name: JUJU_CHANNEL
-            default: candidate
+            default: stable
             description: The channel to push the charm to (stable, candidate, beta, edge)
         - CHARM_PUSH_DRY_RUN
         - DISPLAY_NAME
@@ -81,7 +81,7 @@
             description: Git branch.  Generally master or stable/nn.nn.
         - string:
             name: JUJU_CHANNEL
-            default: candidate
+            default: stable
             description: The channel to push the charm to (stable, candidate, beta, edge)
         - CHARM_PUSH_DRY_RUN
         - DISPLAY_NAME


### PR DESCRIPTION
It was misconfigured to push to the candidate channel rather than
stable.