### PR TITLE
Disable charms for charmhub migration experiments

### DIFF
--- a/config/jjb-templates/project-charm-pusher.yaml
+++ b/config/jjb-templates/project-charm-pusher.yaml
@@ -46,7 +46,8 @@
       - manila
       - manila-dashboard
       - manila-ganesha
-      - manila-generic
+      # disabled as experimental charm for charmhub migration
+      # - manila-generic
       - manila-netapp
       - masakari
       - masakari-monitors
@@ -56,7 +57,8 @@
       - neutron-api-plugin-arista
       - neutron-api-plugin-ironic
       - neutron-api-plugin-ovn
-      - neutron-dynamic-routing
+      # disabled as experimental charm for charmhub migration
+      # - neutron-dynamic-routing
       - neutron-gateway
       - neutron-openvswitch
       - nova-cell-controller


### PR DESCRIPTION
As part of the charmhub migration two charms have been selected to be
'split' so that charmhub publishing can be verified.  Thus, the pushers
in the Jenkins CI are being disabled so that the charmstore is no longer
updated for those two charms.  This is to avoid a 'split-brain' syndrome
of incorrect information between the two stores.