### PR TITLE
Disable all the charm-pushers for charmhub migration

### DIFF
--- a/config/jjb-templates/project-charm-pusher-x.yaml
+++ b/config/jjb-templates/project-charm-pusher-x.yaml
@@ -24,7 +24,7 @@
 - job-template:
     name: 'charm_pusher_x_{charm}_master'
     node: task
-    disabled: false
+    disabled: true
     parameters:
         - string:
             name: BASE_NAME
@@ -69,7 +69,7 @@
 - job-template:
     name: 'charm_pusher_x_{charm}_stable'
     node: task
-    disabled: false
+    disabled: true
     parameters:
         - string:
             name: BASE_NAME

--- a/config/jjb-templates/project-charm-pusher.yaml
+++ b/config/jjb-templates/project-charm-pusher.yaml
@@ -103,7 +103,7 @@
 - job-template:
     name: 'charm_pusher_{charm}_master'
     node: task
-    disabled: false
+    disabled: true
     parameters:
         - string:
             name: BASE_NAME
@@ -147,7 +147,7 @@
 - job-template:
     name: 'charm_pusher_{charm}_stable'
     node: task
-    disabled: false
+    disabled: true
     parameters:
         - string:
             name: BASE_NAME


### PR DESCRIPTION
Disable all the charm pushers as its going over to charmhub.
These will be removed in a future update.